### PR TITLE
time.clock() has been removed in Python 3.8 (deprecated since 3.3).  …

### DIFF
--- a/hexgen/util.py
+++ b/hexgen/util.py
@@ -164,11 +164,11 @@ class Timer:
         if self.debug:
             print(self.text.ljust(50), end="")
             print('starting...')
-        self.start = time.clock()
+        self.start = time.perf_counter()
         return self
 
     def __exit__(self, *args):
-        self.end = time.clock()
+        self.end = time.perf_counter()
         self.interval = self.end - self.start
         if self.debug:
             print(self.text.ljust(50), end="")


### PR DESCRIPTION
…Replaced .clock() with perf_counter().